### PR TITLE
Fixes for smaller screens, especially for object panel and context menu

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -25,15 +25,47 @@ class Game extends React.Component {
 		this.playerMovesLimit = 3;
 		this.playerActionsLimit = 2;
 
-		this.minScreenWidth = 1000;
+		this.minScreenWidthForSmall = 1000;
+		this.minScreenWidthForNarrow = 768;
 		this.minScreenHeight = 768;
-		this.objectPanelWidth = 300;
+		this.objectPanelWidth = 400;
 		this.objectPanelHeight = 250;
 		this.contextMenuWidth = 128;
 		this.contextMenuHeight = 32;
 		this.uiControlBarHeight = 160;
 
 		this.firebase = new Firebase();
+
+		this.notEnoughSpaceDialogProps = {
+			dialogContent: "That character's inventory space is full. Drop or trade out something first.",
+			closeButtonText: 'Ok',
+			closeButtonCallback: null,
+			disableCloseButton: false,
+			actionButtonVisible: false,
+			actionButtonText: '',
+			actionButtonCallback: null,
+			dialogClasses: ''
+		};
+		this.noMoreActionsDialogProps = {
+			dialogContent: 'That character has no more actions this turn',
+			closeButtonText: 'Ok',
+			closeButtonCallback: null,
+			disableCloseButton: false,
+			actionButtonVisible: false,
+			actionButtonText: '',
+			actionButtonCallback: null,
+			dialogClasses: ''
+		};
+		this.noMoreMovesDialogProps = {
+			dialogContent: 'That character has no more moves this turn',
+			closeButtonText: 'Ok',
+			closeButtonCallback: null,
+			disableCloseButton: false,
+			actionButtonVisible: false,
+			actionButtonText: '',
+			actionButtonCallback: null,
+			dialogClasses: ''
+		};
 
 		/**
 		 * Creature data structure : {
@@ -56,7 +88,8 @@ class Game extends React.Component {
 			screenData: {
 				width: window.innerWidth,
 				height: window.innerHeight,
-				isNarrow: window.innerWidth < this.minScreenWidth,// && window.innerWidth < window.innerHeight,
+				isSmall: window.innerWidth < this.minScreenWidthForSmall || window.innerHeight < this.minScreenHeight,
+				isNarrow: window.innerWidth < this.minScreenWidthForNarrow && window.innerWidth < window.innerHeight,
 				isShort: window.innerHeight < this.minScreenHeight && window.innerHeight < window.innerWidth,
 				isIOS: navigator.userAgent.includes('iPhone OS')
 			},
@@ -106,37 +139,6 @@ class Game extends React.Component {
 			centerOnPlayer: false,
 			logText: []
 		}
-
-		this.notEnoughSpaceDialogProps = {
-			dialogContent: "That character's inventory space is full. Drop or trade out something first.",
-			closeButtonText: 'Ok',
-			closeButtonCallback: null,
-			disableCloseButton: false,
-			actionButtonVisible: false,
-			actionButtonText: '',
-			actionButtonCallback: null,
-			dialogClasses: ''
-		};
-		this.noMoreActionsDialogProps = {
-			dialogContent: 'That character has no more actions this turn',
-			closeButtonText: 'Ok',
-			closeButtonCallback: null,
-			disableCloseButton: false,
-			actionButtonVisible: false,
-			actionButtonText: '',
-			actionButtonCallback: null,
-			dialogClasses: ''
-		};
-		this.noMoreMovesDialogProps = {
-			dialogContent: 'That character has no more moves this turn',
-			closeButtonText: 'Ok',
-			closeButtonCallback: null,
-			disableCloseButton: false,
-			actionButtonVisible: false,
-			actionButtonText: '',
-			actionButtonCallback: null,
-			dialogClasses: ''
-		};
 	}
 
 	/**
@@ -176,7 +178,8 @@ class Game extends React.Component {
 		const screenData = {...this.state.screenData};
 		screenData.width = window.innerWidth;
 		screenData.height = window.innerHeight;
-		screenData.isNarrow = screenData.width < this.minScreenWidth;// && screenData.width < screenData.height;
+		screenData.isSmall = window.innerWidth < this.minScreenWidthForSmall || window.innerHeight < this.minScreenHeight;
+		screenData.isNarrow = screenData.width < this.minScreenWidthForNarrow && screenData.width < screenData.height;
 		screenData.isShort = screenData.height < this.minScreenHeight && screenData.height < screenData.width;
 		this.setState({screenData});
 	}

--- a/client/src/Map.js
+++ b/client/src/Map.js
@@ -2542,6 +2542,7 @@ class Map extends React.Component {
 		}
 		if (prevProps.screenData.width !== this.props.screenData.width ||
 			prevProps.screenData.height !== this.props.screenData.height ||
+			prevProps.screenData.isSmall !== this.props.screenData.isSmall ||
 			prevProps.screenData.isNarrow !== this.props.screenData.isNarrow ||
 			prevProps.screenData.isShort !== this.props.screenData.isShort ||
 			prevProps.gameOptions.screenZoom !== this.props.gameOptions.screenZoom)

--- a/client/src/UI.js
+++ b/client/src/UI.js
@@ -573,11 +573,15 @@ class UI extends React.Component {
 			const yBuffer = 80;
 			const leftMod = x > (window.innerWidth - panelWidth) ? -(panelWidth + xBuffer) : 0;
 			const halfScreenHeight = this.props.screenData.height / 2;
-			const controlBarTopPos = this.props.screenData.height - this.props.uiControlBarHeight;
-			// if context menu or clicked item is top half of screen, position at cursor;
-			// or if clicking pick up action button, push up 3x buffer;
-			// otherwise, clicked lower half of screen, push up 1x buffer
-			const topMod = (panelType === 'menu') || (y < halfScreenHeight) ? 0 : y > controlBarTopPos ? -(yBuffer * 3) : -yBuffer;
+			const controlBarTopPos = this.props.screenData.height - this.props.uiControlBarHeight - yBuffer;
+			let topMod = 0;
+			// if context menu and clicked at bottom of screen (below where top of control bar is), bump up a little
+			if (panelType === 'menu' && y > controlBarTopPos) {
+				topMod = -yBuffer;
+			// else if object panel and clicked at lower half of screen, bump up a lot if below top of control bar height or a little if above control bar
+			} else if (panelType === 'object' && y > halfScreenHeight) {
+				topMod = y > controlBarTopPos ? -(yBuffer * 3) : -yBuffer;
+			}
 			coords = {left: x + leftMod, top: y + topMod};
 		}
 		return coords;

--- a/client/src/UIElements.js
+++ b/client/src/UIElements.js
@@ -129,13 +129,13 @@ function CharacterControls(props) {
 		</div>
 	);
 
-	const displayCharName = ((props.screenData.isNarrow || props.screenData.isShort) && props.characterId === props.selectedControlTab) || (!props.screenData.isNarrow && !props.screenData.isShort);
+	const displayCharName = !props.screenData.isSmall || (props.screenData.isSmall && props.characterId === props.selectedControlTab);
 	const healthLevel = (currentPCdata.currentHealth / currentPCdata.startingHealth) * 100;
 	const sanityLevel = (currentPCdata.currentSanity / currentPCdata.startingSanity) * 100;
 	const spiritLevel = (currentPCdata.currentSpirit / currentPCdata.startingSpirit) * 100;
 	return (
 		<div
-			id={`${((props.screenData.isNarrow || props.screenData.isShort) && props.characterId === props.selectedControlTab) ? 'control-bar-tab-1' : ''}`}
+			id={`${(props.screenData.isSmall && props.characterId === props.selectedControlTab) ? 'control-bar-tab-1' : ''}`}
 			className='control-bar-tab-container'
 			onDragOver={(evt) => handleItemOverDropZone(evt)}
 			onDrop={(evt) => props.dropItemToPC(evt, props.characterId)}>
@@ -172,7 +172,7 @@ function CharacterControls(props) {
 			</div>
 			<div
 				id={`char-control-${props.characterId}`}
-				className={`control-bar-buttons-container ${((props.screenData.isNarrow || props.screenData.isShort) && props.characterId !== props.selectedControlTab) ? 'hide' : ''}`}>
+				className={`control-bar-buttons-container ${(props.screenData.isSmall && props.characterId !== props.selectedControlTab) ? 'hide' : ''}`}>
 				{weaponButtons}
 				{medicineButtons}
 				<div className='misc-action-buttons-container'>
@@ -413,7 +413,10 @@ function ObjectInfoPanel(props) {
 					<div key={obj.id}>
 						<div className='object-row-with-buttons'>
 							<div className={`inv-object ${convertObjIdToClassId(obj.id)}`}></div>
-							<div className='font-fancy object-list-objname'>{obj.name}</div>
+							<div>
+								<div className='font-fancy object-list-objname'>{obj.name}</div>
+								<div>{obj.description}</div>
+							</div>
 							{isPickUpAction &&
 								<div className='general-button' onClick={() => updateObjToShow(obj)}>Show</div>
 							}

--- a/client/src/css/ui.css
+++ b/client/src/css/ui.css
@@ -744,7 +744,7 @@ select {
 
 .object-info-panel, .skill-info-panel {
 	position: fixed;
-	max-width: 400px;
+	width: 400px;
 	max-height: 400px;
 	padding: 10px;
 	background-color: #225555;
@@ -1236,8 +1236,7 @@ select {
 	}
 
 	.object-info-panel {
-		width: 90%;
-		max-width: unset;
+		width: 100%;
 		left: 5%;
 	}
 
@@ -1300,6 +1299,7 @@ select {
 	}
 
 	.log-container {
+		max-height: 100px;
 		border: 0;
 		border-bottom: 1px solid seagreen;
 	}


### PR DESCRIPTION
Adding isSmall attr to screenData to differentiate from isNarrow to allow for ui positioning on smaller screens that's independent of orientation (so isNarrow is able to be used more specifically for small screens in portrait)
Fixing positioning of context menu on small screens
Setting object panel width to 400 for large screens