### PR TITLE
Fixing light refill crash 

### DIFF
--- a/client/src/UI.js
+++ b/client/src/UI.js
@@ -881,12 +881,6 @@ class UI extends React.Component {
 						updateActiveCharacter={this.props.updateActiveCharacter}
 						updateFollowModePositions={this.props.updateFollowModePositions}
 						endTurnCallback={this.props.updateCurrentTurn}
-						toggleActionButton={this.props.toggleActionButton}
-						updateUnitSelectionStatus={this.props.updateUnitSelectionStatus}
-						characterIsSelected={this.props.characterIsSelected}
-						characterInfo={this.props.selectedCharacterInfo}
-						creatureIsSelected={this.props.creatureIsSelected}
-						creatureInfo={this.props.selectedCreatureInfo}
 					/>}
 					{/*<div className='minimize-button general-button' onClick={() => {*/}
 					{/*	this.minimizePanel('turnInfo');*/}

--- a/client/src/UIElements.js
+++ b/client/src/UIElements.js
@@ -178,7 +178,20 @@ function CharacterControls(props) {
 				<div className='misc-action-buttons-container'>
 					{((currentPCdata.equippedLight && (currentPCdata.equippedLight.includes('lantern') || currentPCdata.equippedLight.includes('torch'))) &&
 					currentPCdata.lightTime < currentPCdata.items[currentPCdata.equippedLight].maxTime && currentPCdata.items.oil0) &&
-					<div className={`action-button refill-action ${actionButtonState}`} onClick={() => props.refillLight()}></div>
+					<div className={`action-button refill-action ${actionButtonState}`} onClick={() => {
+						const availOil = currentPCdata.items.oil0 && currentPCdata.items.oil0.amount;
+						// if reloading light uses up remaining oil in inv, remove oil item in inv and update inventory in UI
+						if (availOil <= (currentPCdata.items[currentPCdata.equippedLight].maxTime - currentPCdata.lightTime)) {
+							let updatedInventory = props.entireInventory[props.characterId];
+							const oilInvIndex = updatedInventory.indexOf('oil0');
+							updatedInventory.splice(oilInvIndex, 1);
+							props.updateInventory(props.characterId, updatedInventory, () => {
+								props.refillLight();
+							});
+						} else {
+							props.refillLight();
+						}
+					}}></div>
 					}
 					{(props.mapObjectsOnPcTiles.length > 0) &&
 						<div className={`action-button pickup-action ${actionButtonState}`} onClick={(evt) => props.setMapObjectSelected(props.mapObjectsOnPcTiles, evt, true)}></div>


### PR DESCRIPTION
Crash occurred when refilling light source with all remaining oil - componentDidUpdate in UI doesn't seem to be firing when refillLight or reloadGun are called from UIElements, so needing to manually update entireInventory in UI when entire ammo/oil item is used up. 
Removing unnecessary props for ModeInfoPanel